### PR TITLE
Fixes the "How to Star a Repository" image

### DIFF
--- a/src/installed.md
+++ b/src/installed.md
@@ -12,8 +12,7 @@ If you would like to support Schooltape, you can do so by starring the [reposito
 <img
 src="https://docs.github.com/assets/cb-8462/mw-1440/images/help/stars/unstarring-a-repository.webp"
 alt="How to star a repository"
-width="500"
->
+width="500">
 :::
 
 You can also help to improve Schooltape by [contributing](/contributing/index.md) to the project.


### PR DESCRIPTION
The image wasn't showing because the > was in the wrong place, so it showed the html code instead of the image. So I added it in the right spot. You can view the error below.
![image](https://github.com/schooltape/schooltape.github.io/assets/163376618/04497bb4-e762-438e-8791-0d3b5174e31b)
